### PR TITLE
automatically configure api_compute

### DIFF
--- a/pc_lib/pc_lib_api.py
+++ b/pc_lib/pc_lib_api.py
@@ -4,6 +4,7 @@ import logging
 
 from .posture import PrismaCloudAPIPosture
 from .compute import PrismaCloudAPICompute
+from .pc_lib_utility import PrismaCloudUtility
 
 # --Description-- #
 
@@ -60,3 +61,10 @@ class PrismaCloudAPI(PrismaCloudAPIPosture, PrismaCloudAPICompute):
         filehandler.setFormatter(formatter)
         self.logger.addHandler(filehandler)
         self.logger.error = CallCounter(self.logger.error)
+        self.auto_configure_compute()
+
+    def auto_configure_compute(self):
+        if self.api and not self.api_compute:
+            meta_info = self.meta_info()
+            if meta_info and 'twistlockUrl' in meta_info:
+                self.api_compute = PrismaCloudUtility.normalize_api_compute_base(meta_info['twistlockUrl'])

--- a/pc_lib/posture/_endpoints.py
+++ b/pc_lib/posture/_endpoints.py
@@ -457,3 +457,19 @@ class EndpointsPrismaCloudAPIMixin():
         #    # download ready
         #    pass
         #else:
+
+    """
+    Configuration
+
+    [ ] LIST
+    [ ] CREATE
+    [x] READ
+    [ ] UPDATE
+    [ ] DELETE
+    """
+
+    def compute_config(self):
+        return self.execute('GET', 'compute/config')
+
+    def meta_info(self):
+        return self.execute('GET', 'meta_info')


### PR DESCRIPTION
## Description

Use one of two available, if undocumented, endpoints to automatically configure `--api_compute` 
aka  `Compute > Manage > System > Utilities > Path to Console`

Will document after customer testing.

## Motivation and Context

Use available configuration data.

## How Has This Been Tested?

Manually

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
