### PR TITLE
normalize ca_bundle, as verify can be a boolean or a path to a file

### DIFF
--- a/pc_lib/pc_lib_api.py
+++ b/pc_lib/pc_lib_api.py
@@ -30,7 +30,7 @@ class PrismaCloudAPI(PrismaCloudAPIPosture, PrismaCloudAPICompute):
         self.api_compute        = ""
         self.username           = None
         self.password           = None
-        self.ca_bundle          = ""
+        self.ca_bundle          = True
         #
         self.token              = None
         self.token_timer        = 0
@@ -46,13 +46,18 @@ class PrismaCloudAPI(PrismaCloudAPIPosture, PrismaCloudAPICompute):
         return 'PrismaCloudAPI:\n  API: %s\n  Compute API: %s\n  API Error Count: %s\n  API Token: %s' % (self.api, self.api_compute, self.logger.error.counter, self.token)
 
     def configure(self, settings):
-        # Required. (One of these api/api_compute is required.)
+        # One of API (--api) or API Compute (--api_compute) are required.
         self.api         = settings['apiBase']
         self.api_compute = settings['api_compute']
         self.username    = settings['username']
         self.password    = settings['password']
-        # Optional.
-        self.ca_bundle   = settings['ca_bundle']
+        # Used as the verify parameter of the requests.request() method: which can be a boolean or a path to a file.
+        if settings['ca_bundle']:
+            if settings['ca_bundle'] == 'True':
+                settings['ca_bundle'] = True
+            elif settings['ca_bundle'] == 'False':
+                settings['ca_bundle'] = False
+            self.ca_bundle = settings['ca_bundle']
         # Logging!
         self.logger = logging.getLogger(__name__)
         formatter   = logging.Formatter(fmt='%(asctime)s: %(levelname)s: %(message)s', datefmt='%Y-%m-%d %I:%M:%S %p')

--- a/pc_lib/pc_lib_utility.py
+++ b/pc_lib/pc_lib_utility.py
@@ -113,8 +113,6 @@ class PrismaCloudUtility():
         settings['password']    = args.password
         settings['api_compute'] = self.normalize_api_compute_base(args.api_compute)
         settings['ca_bundle']   = args.ca_bundle
-        if settings['ca_bundle'] == 'False':
-            settings['ca_bundle'] = False
         self.write_json_file(settings_file_name, settings, pretty=True)
 
     # Return user-specified settings file, or the default settings file.


### PR DESCRIPTION
## Description

Allow `ca_bundle` which is used by `requests.request(verify=)` to be unspecified or a specified as a string, and convert to any boolean strings to boolean values.

## Motivation and Context

Avoid SSL errors and warnings.

## How Has This Been Tested?

pylint, manual testing

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
