### PR TITLE
PC Azure Tenant Synchronization in Compute

### DIFF
--- a/pc_lib/compute/__init__.py
+++ b/pc_lib/compute/__init__.py
@@ -2,12 +2,13 @@
 
 import sys
 
-from .compute     import PrismaCloudAPIComputeMixin
-from ._containers import ContainersPrismaCloudAPIComputeMixin
-from ._images     import ImagesPrismaCloudAPIComputeMixin
-from ._registry   import RegistryPrismaCloudAPIComputeMixin
-from ._scans      import ScansPrismaCloudAPIComputeMixin
-from ._status     import StatusPrismaCloudAPIComputeMixin
+from .compute      import PrismaCloudAPIComputeMixin
+from ._containers  import ContainersPrismaCloudAPIComputeMixin
+from ._credentials import CredentialsPrismaCloudAPIComputeMixin
+from ._images      import ImagesPrismaCloudAPIComputeMixin
+from ._registry    import RegistryPrismaCloudAPIComputeMixin
+from ._scans       import ScansPrismaCloudAPIComputeMixin
+from ._status      import StatusPrismaCloudAPIComputeMixin
 
 mixin_classes_as_strings = list(filter(lambda x: x.endswith('PrismaCloudAPIComputeMixin'), dir()))
 mixin_classes = [getattr(sys.modules[__name__], x) for x in mixin_classes_as_strings]

--- a/pc_lib/compute/_credentials.py
+++ b/pc_lib/compute/_credentials.py
@@ -1,6 +1,5 @@
 """ Prisma Cloud Compute API Images Endpoints Class """
 
-import json
 import urllib.parse
 
 # Credentials (Manage > Authentication > Credentials store)
@@ -12,14 +11,14 @@ class CredentialsPrismaCloudAPIComputeMixin:
     def credential_list_read(self):
         return self.execute_compute('GET', '/api/v1/credentials')
 
-    def credential_list_create(self, id, cloud_type, secret, description):
+    def credential_list_create(self, _id, cloud_type, secret, description):
         body = {
             'secret': secret,
             'serviceAccount': {},
             'type': cloud_type,
             'description': description,
             'skipVerify': False,
-            '_id': id
+            '_id': _id
         }
         return self.execute_compute(
             'POST', 'api/v1/credentials?project=Central+Console',

--- a/pc_lib/compute/_credentials.py
+++ b/pc_lib/compute/_credentials.py
@@ -11,15 +11,7 @@ class CredentialsPrismaCloudAPIComputeMixin:
     def credential_list_read(self):
         return self.execute_compute('GET', '/api/v1/credentials')
 
-    def credential_list_create(self, _id, cloud_type, secret, description):
-        body = {
-            'secret': secret,
-            'serviceAccount': {},
-            'type': cloud_type,
-            'description': description,
-            'skipVerify': False,
-            '_id': _id
-        }
+    def credential_list_create(self, body):
         return self.execute_compute(
             'POST', 'api/v1/credentials?project=Central+Console',
             body_params=body

--- a/pc_lib/compute/_credentials.py
+++ b/pc_lib/compute/_credentials.py
@@ -1,0 +1,32 @@
+""" Prisma Cloud Compute API Images Endpoints Class """
+
+import json
+import urllib.parse
+
+# Credentials (Manage > Authentication > Credentials store)
+
+
+class CredentialsPrismaCloudAPIComputeMixin:
+    """ Prisma Cloud Compute API Credentials Endpoints Class """
+
+    def credential_list_read(self):
+        return self.execute_compute('GET', '/api/v1/credentials')
+
+    def credential_list_create(self, id, cloud_type, secret, description):
+        body = {
+            'secret': secret,
+            'serviceAccount': {},
+            'type': cloud_type,
+            'description': description,
+            'skipVerify': False,
+            '_id': id
+        }
+        return self.execute_compute(
+            'POST', 'api/v1/credentials?project=Central+Console',
+            body_params=body
+        )
+
+    def credential_list_delete(self, cred):
+        return self.execute_compute(
+            'DELETE', '/api/v1/credentials/%s' % urllib.parse.quote(cred)
+        )

--- a/pc_lib/posture/_endpoints.py
+++ b/pc_lib/posture/_endpoints.py
@@ -277,6 +277,9 @@ class EndpointsPrismaCloudAPIMixin():
     def cloud_accounts_list_read(self, query_params=None):
         return self.execute('GET', 'cloud', query_params=query_params)
 
+    def cloud_accounts_children_list_read(self, cloud_account_type, cloud_account_id):
+        return self.execute('GET', '/cloud/%s/%s/project' % (cloud_account_type, cloud_account_id))
+
     def cloud_accounts_list_names_read(self, query_params=None):
         return self.execute('GET', 'cloud/name', query_params=query_params)
 

--- a/pcs_sync_azure_accounts.py
+++ b/pcs_sync_azure_accounts.py
@@ -166,5 +166,5 @@ for child in pc_api.cloud_accounts_children_list_read('azure', args.tenant):
             )
             print(' Success')
         else:
-            print('DRYRUN - Adding account \"%s\" to compute credentials'
+            print('DRYRN - Adding account \"%s\" to compute credentials'
                   % child['name'])

--- a/pcs_sync_azure_accounts.py
+++ b/pcs_sync_azure_accounts.py
@@ -47,6 +47,9 @@ pc_api.validate_api_compute()
 
 # --Main-- #
 
+add_counter = 0
+del_counter = 0
+
 print('INFO  - Testing Compute API Access ...', end='')
 intelligence = pc_api.statuses_intelligence()
 print(' Success.')
@@ -138,6 +141,7 @@ for cred in tenant_creds:
             print(' Success')
         else:
             print('DRYRN - Removing credential \"%s\" from compute' % cred)
+        del_counter+=1
 
 # Iterate through the list of children accounts...
 for child in pc_api.cloud_accounts_children_list_read('azure', args.tenant):
@@ -154,17 +158,26 @@ for child in pc_api.cloud_accounts_children_list_read('azure', args.tenant):
             'encrypted': '',
             'plain': json.dumps(service_key_dict)
         }
+        # Build body for API
+        body = {
+            'secret': secret,
+            'serviceAccount': {},
+            'type': 'azure',
+            'description': 'Added by automation',
+            'skipVerify': False,
+            '_id': child['name']
+        }
+
         # Add credential
         if not args.dryrun:
             print('API   - Adding account \"%s\" to compute credentials ...'
                   % child['name'], end='')
-            pc_api.credential_list_create(
-                child['name'],
-                'azure',
-                secret,
-                'Added by automation'
-            )
+            pc_api.credential_list_create(body)
             print(' Success')
         else:
             print('DRYRN - Adding account \"%s\" to compute credentials'
                   % child['name'])
+        add_counter+=1
+
+print('Total Added   : %s' %add_counter)
+print('Total Deleted : %s' %del_counter)

--- a/pcs_sync_azure_accounts.py
+++ b/pcs_sync_azure_accounts.py
@@ -1,0 +1,169 @@
+""" Synchronize Azure Accounts from PC to PCC """
+
+from __future__ import print_function
+from pc_lib import pc_api, pc_utility
+from operator import itemgetter
+import json
+
+# --Configuration-- #
+
+parser = pc_utility.get_arg_parser()
+parser.add_argument(
+    '--tenant',
+    type=str,
+    required=True,
+    help='Account ID of Tenant to sync.')
+parser.add_argument(
+    '--dryrun',
+    action='store_true',
+    help='Set flag for dryrun mode')
+parser.add_argument(
+    '--service_key',
+    default=None,
+    type=str,
+    help='(Optional) - Path to file containing Tenant\'s AZ SP Service Key')
+args = parser.parse_args()
+
+
+# --Helpers-- #
+def read_service_key(service_key_file):
+    try:
+        json_key = open(args.service_key, 'rb')
+        print(' Success.')
+    except OSError:
+        print(' Error.')
+        print ('ERROR - Could not open/read file: %s' % args.service_key)
+        exit()
+    with json_key:
+        service_key = json.load(json_key)
+    return(service_key)
+
+# --Initialize-- #
+
+settings = pc_utility.get_settings(args)
+pc_api.configure(settings)
+pc_api.validate_api_compute()
+
+# --Main-- #
+
+print('INFO  - Testing Compute API Access ...', end='')
+intelligence = pc_api.statuses_intelligence()
+print(' Success.')
+
+print('API   - Getting the current list of Cloud Accounts ...', end='')
+cloud_accounts_list = pc_api.cloud_accounts_list_read()
+print(' Success.')
+
+print('API   - Getting the current list of Compute Credentials ...', end='')
+compute_credential_list = pc_api.credential_list_read()
+print(' Success.')
+
+# If args.service_key is defined, open file and compare tenant id
+# to args.tenant.
+# If successful, store service key as dictionary: service_key
+if args.service_key:
+    print('INFO  - Opening Service Key File ...', end='')
+    service_key = read_service_key(args.service_key)
+    print('INFO  - Validate Service Key ...', end='')
+    if service_key['tenantId'] != args.tenant:
+        print(' Error.')
+        print('ERROR - Service Key provided does not match requested '
+              'tenant: %s' % args.tenant)
+        exit()
+    print(' Success.')
+
+# Build list of cloud accounts with account id's that match input args.tenant
+# There should be only one match.  If not, the account wasn't on-boarded or
+# there is an error with the data.
+tenant_name = list(map(itemgetter('name'), (
+    list(
+        filter(
+            lambda item: (
+                (item['accountId'] == args.tenant) and
+                (item['accountType'] == 'tenant')
+            ), cloud_accounts_list
+        )
+    ))))
+print('INFO  - Validate tenant credential to be added to compute ...', end='')
+if (len(tenant_name) < 1):
+    print(' Error.')
+    print('ERROR - Could not find tenant \"%s\" in Prisma Cloud Accounts.'
+          % args.tenant)
+    exit()
+elif (len(tenant_name) > 1):
+    print(' Error.')
+    print('ERROR - Too many Prisma Cloud Accounts matched tenant \"%s\".'
+          % args.tenant)
+else:
+    tenant_name = ' '.join(map(str, tenant_name))
+    print(' Success.')
+
+print('API   - Getting all children accounts in tenant ...', end='')
+children = pc_api.cloud_accounts_children_list_read('azure', args.tenant)
+print(' Success.')
+
+# var cloud_account_names = list of all tenant's children's names
+# var children = list of dict for all children cloud accounts
+cloud_account_names = []
+for child_account in children:
+    if (child_account['accountType'] == 'account'):
+        cloud_account_names.append(child_account['name'])
+
+if (len(cloud_account_names) < 1):
+    print('INFO  - No children accounts in tenant to add to compute.')
+
+# Generate a list of Compute Credentials associated with tenant and store
+# as tenant_creds.
+# var tenant_name = string of name of tenant
+# var tenant_creds = list of all compute credentials belonging to args.tenant
+tenant_creds = []
+for cred in compute_credential_list:
+    if (
+        ('description' in cred) and
+        (tenant_name in cred['_id']) and
+        (cred['type'] == 'azure')
+    ):
+        tenant_creds.append(cred['_id'])
+
+# Interate through compute credential names and compare to cloud account
+# tenant children.
+# If not in children, remove credential from compute.
+for cred in tenant_creds:
+    if cred not in cloud_account_names:
+        if not args.dryrun:
+            print('API   - Removing credential \"%s\" from compute ...'
+                  % cred, end='')
+            pc_api.credential_list_delete(cred)
+            print(' Success')
+        else:
+            print('DRYRN - Removing credential \"%s\" from compute' % cred)
+
+# Iterate through the list of children accounts...
+for child in pc_api.cloud_accounts_children_list_read('azure', args.tenant):
+    # and match and child that is both accountType == "account" and is not
+    # already in compute_credential_list
+    if (
+        (child['accountType'] == 'account') and
+        (not any(d['_id'] == child['name'] for d in compute_credential_list))
+    ):
+        # for each child account being add, insert associated subscription
+        # id into service_key
+        service_key['subscriptionId'] = child['accountId']
+        secret = {
+            'encrypted': '',
+            'plain': json.dumps(service_key)
+        }
+        # Add credential
+        if not args.dryrun:
+            print('API   - Adding account \"%s\" to compute credentials ...'
+                  % child['name'], end='')
+            pc_api.credential_list_create(
+                child['name'],
+                'azure',
+                secret,
+                'Added by automation'
+            )
+            print(' Success')
+        else:
+            print('DRYRUN - Adding account \"%s\" to compute credentials'
+                  % child['name'])


### PR DESCRIPTION
## Description

Created new compute api wrappers for credentials at pc_lib/compute/_credentials.py
  credential_list_read
  credential_list_create
  credential_list_delete

Added cloud_accounts_children_list_read API wrapper to pc_lib/posture/_endpoints.py

Created script using the following libs at pcs_sync_azure_accounts.py
  credential_list_read
  credential_list_create
  credential_list_delete
  cloud_accounts_children_list_read
  cloud_accounts_list_read


pcs_sync_azure_accounts.py takes the following args:
  tenant : reflects the Prisma Cloud Azure tenant to sync
  service_key : reflects the path to the service_key of the tenants spn
  dryrun : reports on what will be done but does not create or delete compute credentials

## Motivation and Context

Synchronizes credentials in compute with tenant in prisma cloud.  uses spn service key for registration.

## How Has This Been Tested?

manual tests run to validate:
  read and validation of service key
  validate tenant exists in prisma cloud
  validates children exist in prisma cloud
  checks for existance of existing tenants in compute and adds new
  removes creds from compute if subscritption was removed in prisma cloud

- New feature (non-breaking change which adds functionality)

## Checklist

- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes if appropriate.
- [ X ] All new and existing tests passed.
