### PR TITLE
Updates to pc_api libraries and pcs_sync_azure_accounts to handle credential usages

### DIFF
--- a/pc_lib/compute/__init__.py
+++ b/pc_lib/compute/__init__.py
@@ -6,8 +6,10 @@ from .compute      import PrismaCloudAPIComputeMixin
 from ._containers  import ContainersPrismaCloudAPIComputeMixin
 from ._credentials import CredentialsPrismaCloudAPIComputeMixin
 from ._images      import ImagesPrismaCloudAPIComputeMixin
+from ._policies    import PoliciesPrismaCloudAPIComputeMixin
 from ._registry    import RegistryPrismaCloudAPIComputeMixin
 from ._scans       import ScansPrismaCloudAPIComputeMixin
+from ._settings    import SettingsPrismaCloudAPIComputeMixin
 from ._status      import StatusPrismaCloudAPIComputeMixin
 
 mixin_classes_as_strings = list(filter(lambda x: x.endswith('PrismaCloudAPIComputeMixin'), dir()))

--- a/pc_lib/compute/_credentials.py
+++ b/pc_lib/compute/_credentials.py
@@ -9,7 +9,7 @@ class CredentialsPrismaCloudAPIComputeMixin:
     """ Prisma Cloud Compute API Credentials Endpoints Class """
 
     def credential_list_read(self):
-        return self.execute_compute('GET', '/api/v1/credentials')
+        return self.execute_compute('GET', 'api/v1/credentials')
 
     def credential_list_create(self, body):
         return self.execute_compute(
@@ -20,4 +20,9 @@ class CredentialsPrismaCloudAPIComputeMixin:
     def credential_list_delete(self, cred):
         return self.execute_compute(
             'DELETE', '/api/v1/credentials/%s' % urllib.parse.quote(cred)
+        )
+
+    def credential_list_usages_read(self, cred):
+        return self.execute_compute(
+            'GET', '/api/v1/credentials/%s/usages' % urllib.parse.quote(cred)
         )

--- a/pc_lib/compute/_policies.py
+++ b/pc_lib/compute/_policies.py
@@ -1,0 +1,15 @@
+""" Prisma Cloud Compute API Policies Endpoints Class """
+
+# Credentials (Defend > Compliance)
+
+class PoliciesPrismaCloudAPIComputeMixin:
+    """ Prisma Cloud Compute API Credentials Endpoints Class """
+
+    def policies_cloud_platforms_read(self):
+        return self.execute_compute('GET', 'api/v1/policies/cloud-platforms')
+
+    def policies_cloud_platforms_write(self, body):
+        return self.execute_compute(
+            'put', 'api/v1/policies/cloud-platforms',
+            body_params=body
+        )

--- a/pc_lib/compute/_settings.py
+++ b/pc_lib/compute/_settings.py
@@ -1,0 +1,24 @@
+""" Prisma Cloud Compute API Settings Endpoints Class """
+
+# Credentials (Defend > Compliance)
+
+class SettingsPrismaCloudAPIComputeMixin:
+    """ Prisma Cloud Compute API Settings Endpoints Class """
+
+    def settings_serverless_scan_read(self):
+        return self.execute_compute('get', 'api/v1/settings/serverless-scan')
+
+    def settings_serverless_scan_write(self, body):
+        return self.execute_compute(
+            'put', 'api/v1/settings/serverless-scan',
+            body_params=body
+        )
+
+    def settings_registry_read(self):
+        return self.execute_compute('get', 'api/v1/settings/registry')
+
+    def settings_registry_write(self, body):
+        return self.execute_compute(
+            'put', 'api/v1/settings/registry',
+            body_params=body
+        )

--- a/pc_lib/posture/_endpoints.py
+++ b/pc_lib/posture/_endpoints.py
@@ -287,7 +287,7 @@ class EndpointsPrismaCloudAPIMixin():
         return self.execute('POST', 'cloud/%s' % cloud_type, body_params=cloud_account_to_add)
 
     def cloud_account_info_read(self, cloud_type, cloud_account_id):
-        return self.execute('GET', 'cloud/%s/%s' % cloud_type, cloud_account_id)
+        return self.execute('GET', 'cloud/%s/%s' % (cloud_type, cloud_account_id))
 
     def cloud_account_update(self, cloud_type, cloud_account_id, cloud_account_update):
         return self.execute('PUT', 'cloud/%s/%s' % (cloud_type, cloud_account_id), body_params=cloud_account_update)

--- a/pc_lib/posture/_endpoints.py
+++ b/pc_lib/posture/_endpoints.py
@@ -286,6 +286,9 @@ class EndpointsPrismaCloudAPIMixin():
     def cloud_accounts_create(self, cloud_type, cloud_account_to_add):
         return self.execute('POST', 'cloud/%s' % cloud_type, body_params=cloud_account_to_add)
 
+    def cloud_account_info_read(self, cloud_type, cloud_account_id):
+        return self.execute('GET', 'cloud/%s/%s' % cloud_type, cloud_account_id)
+
     def cloud_account_update(self, cloud_type, cloud_account_id, cloud_account_update):
         return self.execute('PUT', 'cloud/%s/%s' % (cloud_type, cloud_account_id), body_params=cloud_account_update)
 

--- a/pcs_sync_azure_accounts.py
+++ b/pcs_sync_azure_accounts.py
@@ -3,8 +3,6 @@
 from __future__ import print_function
 import json
 from pc_lib import pc_api, pc_utility
-import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # --Configuration-- #
 


### PR DESCRIPTION
## Description

Added PC Compute Endpoints to pc_api:
  - credential_list_usages_read: identifies where credentials are being used
  - policies_cloud_platforms_read: reads in all cloud accounts configured for discovery
  - policies_cloud_platforms_write: writes all cloud accounts configured for discovery
  - settings_serverless_scan_read: reads in all creds configured for serverless scanning
  - settings_serverless_scan_write: writes all creds configured for serverless scanning
  - settings_registry_read: reads in all configured registries
  - settings_registry_write: writes out configured registries

Added PC Posture Endpoint to pc_api:
  - cloud_account_info_read: read in all cloud account information

Refactored and added functionality to pcs_sync_azure_accounts.py:
  - Removed the need to pass in a SPN service_key as a file.  Now script pulls client ID from newly added cloud_account_info_read function and takes i
n argument of clientSecret.
  - Maps out usages of credentials for cloud discovery, registry scanning, and serverless scanning.  If identified and credential has been tagged for
deletion, removes scanning usages prior to removing credential.

## Motivation and Context

Fixed issue of deleting compute credentials in use for cloud/serverless/registry scanning.

## How Has This Been Tested?

Manual testing of add/remove credentials with and without usages.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Breaking change: removed the --service_key argument to pass in service_key file as this will no just take a clientSecret argument directly (no need for file).

## Checklist

- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes if appropriate.
- [ X ] All new and existing tests passed.
