### PR TITLE
normalize api when read from from a settings file

### DIFF
--- a/pc_lib/pc_lib_utility.py
+++ b/pc_lib/pc_lib_utility.py
@@ -79,13 +79,15 @@ class PrismaCloudUtility():
                 settings['api_compute'] = ''
             if 'ca_bundle' not in settings:
                 settings['ca_bundle'] = ''
+            settings['apiBase']     = self.normalize_api_base(settings['apiBase'])
+            settings['api_compute'] = self.normalize_api_compute_base(settings['api_compute'])
         elif args.api == '' and args.api_compute == '':
             self.error_and_exit(400, 'One of API (--api) or API Compute (--api_compute) are required.')
         else:
             settings['apiBase']     = self.normalize_api_base(args.api)
+            settings['api_compute'] = self.normalize_api_compute_base(args.api_compute)
             settings['username']    = args.username
             settings['password']    = args.password
-            settings['api_compute'] = self.normalize_api_compute_base(args.api_compute)
             settings['ca_bundle']   = args.ca_bundle
         return settings
 


### PR DESCRIPTION
the app* to appi* transformation was missing from this workflow

## Description

normalize api when read from from a settings file

## Motivation and Context

Avoid:

```
<html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>openresty</center>
</body>
</html>
```

## How Has This Been Tested?

manual

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
