### PR TITLE
Auto add of discovered registries

### DIFF
--- a/pc_lib/compute/__init__.py
+++ b/pc_lib/compute/__init__.py
@@ -3,8 +3,8 @@
 import sys
 
 from .compute      import PrismaCloudAPIComputeMixin
-from ._cloud       import CloudPrismaCloudAPIComputeMixin
 from ._containers  import ContainersPrismaCloudAPIComputeMixin
+from ._cloud       import CloudPrismaCloudAPIComputeMixin
 from ._credentials import CredentialsPrismaCloudAPIComputeMixin
 from ._images      import ImagesPrismaCloudAPIComputeMixin
 from ._policies    import PoliciesPrismaCloudAPIComputeMixin

--- a/pc_lib/compute/__init__.py
+++ b/pc_lib/compute/__init__.py
@@ -3,6 +3,7 @@
 import sys
 
 from .compute      import PrismaCloudAPIComputeMixin
+from ._cloud       import CloudPrismaCloudAPIComputeMixin
 from ._containers  import ContainersPrismaCloudAPIComputeMixin
 from ._credentials import CredentialsPrismaCloudAPIComputeMixin
 from ._images      import ImagesPrismaCloudAPIComputeMixin

--- a/pc_lib/compute/__init__.py
+++ b/pc_lib/compute/__init__.py
@@ -3,8 +3,8 @@
 import sys
 
 from .compute      import PrismaCloudAPIComputeMixin
-from ._containers  import ContainersPrismaCloudAPIComputeMixin
 from ._cloud       import CloudPrismaCloudAPIComputeMixin
+from ._containers  import ContainersPrismaCloudAPIComputeMixin
 from ._credentials import CredentialsPrismaCloudAPIComputeMixin
 from ._images      import ImagesPrismaCloudAPIComputeMixin
 from ._policies    import PoliciesPrismaCloudAPIComputeMixin

--- a/pc_lib/compute/_cloud.py
+++ b/pc_lib/compute/_cloud.py
@@ -1,0 +1,9 @@
+""" Prisma Cloud Compute API Cloud Endpoints Class """
+
+# Cloud
+
+class CloudPrismaCloudAPIComputeMixin:
+    """ Prisma Cloud Compute API Cloud Endpoints Class """
+
+    def cloud_discovery_read(self):
+        return self.execute_compute('GET', 'api/v1/cloud/discovery')

--- a/pc_lib/compute/_cloud.py
+++ b/pc_lib/compute/_cloud.py
@@ -1,4 +1,4 @@
-""" Prisma Cloud Compute API Cloud Endpoints Class """
+""" Prisma Compute API Cloud Endpoints Class """
 
 # Cloud
 

--- a/pcs_sync_registries.py
+++ b/pcs_sync_registries.py
@@ -1,0 +1,86 @@
+""" Add discovered registries to Vulnerability->Images->Registry settings """
+
+from __future__ import print_function
+from operator import itemgetter
+from pc_lib import pc_api, pc_utility
+
+# --Configuration-- #
+
+parser = pc_utility.get_arg_parser()
+parser.add_argument(
+    "--collection",
+    type=str,
+    default="All",
+    help="(Optional) - Collection to use for scanning, defaults to All.",
+)
+parser.add_argument(
+    "--serviceType",
+    type=str,
+    choices=["aws-ecr", "azure-acr", "all"],
+    default="all",
+    help="(Optional) - Add all or specific registry types.",
+)
+parser.add_argument("--dryrun", action="store_true", help="Set flag for dryrun mode")
+args = parser.parse_args()
+
+
+# --Helpers-- #
+
+# --Initialize-- #
+
+settings = pc_utility.get_settings(args)
+pc_api.configure(settings)
+pc_api.validate_api_compute()
+
+# --Main-- #
+
+print("API   - Getting all cloud discovered assets ...", end="")
+discovered_cloud_assets = pc_api.cloud_discovery_read()
+print(" Success.")
+
+print("INFO  - Filtering all discovered registries ...", end="")
+discovered_cloud_registries = [
+    item for item in discovered_cloud_assets if "registry" in item
+]
+print(" Success.")
+print("INFO  - Discovered registries ... %s" % len(discovered_cloud_registries))
+print("API   - Getting all configured registries ...", end="")
+configured_registries = pc_api.settings_registry_read()
+print(" Success.")
+configured_registries_list = list(
+    map(itemgetter("registry"), configured_registries["specifications"])
+)
+print("INFO  - Configured registries ... %s" % len(configured_registries_list))
+update = 0
+for d_registry in discovered_cloud_registries:
+    if (
+        args.serviceType in (d_registry["serviceType"], "all")
+    ) and (d_registry["registry"] not in configured_registries_list):
+        print(
+            "INFO  - Adding %s to registry scan queue ..." % d_registry["registry"],
+            end="",
+        )
+        configured_registries["specifications"].append(
+            {
+                "collections": [args.collection],
+                "cap": 5,
+                "os": "linux",
+                "scanners": 2,
+                "registry": d_registry["registry"],
+                "version": d_registry["provider"],
+                "credentialId": d_registry["credentialId"],
+            }
+        )
+        print(" Success.")
+        update = 1
+if update:
+    if args.dryrun:
+        print("DRYRN - Pushing new list of configured registries ... Success.")
+    else:
+        print("API   - Pushing new list of configured registries ...", end="")
+        pc_api.settings_registry_write(
+            {"specifications": configured_registries["specifications"]}
+        )
+        print(" Success.")
+else:
+    print("INFO  - No registries to add.")

--- a/pcs_sync_registries.py
+++ b/pcs_sync_registries.py
@@ -23,7 +23,6 @@ parser.add_argument(
 parser.add_argument("--dryrun", action="store_true", help="Set flag for dryrun mode")
 args = parser.parse_args()
 
-
 # --Helpers-- #
 
 # --Initialize-- #


### PR DESCRIPTION
## Description

1. Added API wrapper to collect assets discovered with cloud discovery

2. Updated Mixin to read in new cloud_discovery_read API wrapper

3. Wrote utility to gather existing configured registries and discovered registries.
   Inputs are registry type (aws-ecr and azure-acr), collection to be used for scanning, and flag for dryrun

## Motivation and Context

Automation of adding discovered registries to simplify setup and configuration.

## How Has This Been Tested?

Discovered new registry and tested addition.
Removed registry and tested a re-add.
Tested with no registries to be added.
Tested with all, aws only, and azure registries.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes if appropriate.
- [ X ] All new and existing tests passed.
