### PR TITLE
refactor cli params

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,6 +17,7 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|([a-z_][a-z0-9_]*)|(__.*__))$
 # Minimum number of public methods for a class (see R0903).
 #
 min-public-methods=1
+max-public-methods=24
 max-args=8
 max-branches=21
 max-nested-blocks=8

--- a/pc_lib/compute/compute.py
+++ b/pc_lib/compute/compute.py
@@ -33,6 +33,7 @@ class PrismaCloudAPIComputeMixin():
 
     # pylint: disable=too-many-arguments,too-many-branches,too-many-locals,too-many-statements
     def execute_compute(self, action, endpoint, query_params=None, body_params=None, force=False, paginated=False):
+        self.suppress_warnings_when_ca_bundle_false()
         if not self.token:
             self.login_compute()
         # Endpoints that have the potential to return large numbers of results return a 'Total-Count' response header.

--- a/pc_lib/pc_lib_api.py
+++ b/pc_lib/pc_lib_api.py
@@ -47,18 +47,11 @@ class PrismaCloudAPI(PrismaCloudAPIPosture, PrismaCloudAPICompute):
 
     def configure(self, settings):
         # One of API (--api) or API Compute (--api_compute) are required.
-        self.api         = settings['apiBase']
+        self.api         = settings['api']
         self.api_compute = settings['api_compute']
         self.username    = settings['username']
         self.password    = settings['password']
-        # Used as the verify parameter of the requests.request() method: which can be a boolean or a path to a file.
-        if settings['ca_bundle']:
-            if settings['ca_bundle'] == 'True':
-                settings['ca_bundle'] = True
-            elif settings['ca_bundle'] == 'False':
-                settings['ca_bundle'] = False
-            self.ca_bundle = settings['ca_bundle']
-        # Logging!
+        self.ca_bundle   = settings['ca_bundle']
         self.logger = logging.getLogger(__name__)
         formatter   = logging.Formatter(fmt='%(asctime)s: %(levelname)s: %(message)s', datefmt='%Y-%m-%d %I:%M:%S %p')
         filehandler = logging.FileHandler(self.error_log)

--- a/pc_lib/posture/posture.py
+++ b/pc_lib/posture/posture.py
@@ -11,7 +11,14 @@ import requests
 class PrismaCloudAPIMixin():
     """ Requests and Output """
 
+    def suppress_warnings_when_ca_bundle_false(self):
+        if self.ca_bundle is False:
+            # Pylint Issue #4584
+            # pylint: disable=no-member
+            requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+
     def login(self, requ_url=None):
+        self.suppress_warnings_when_ca_bundle_false()
         if not requ_url:
             requ_url = 'https://%s/login' % self.api
         requ_action = 'POST'
@@ -26,6 +33,7 @@ class PrismaCloudAPIMixin():
             self.error_and_exit(api_response.status_code, 'API (%s) responded with an error\n%s' % (requ_url, api_response.text))
 
     def extend_login(self):
+        self.suppress_warnings_when_ca_bundle_false()
         requ_url = 'https://%s/auth_token/extend' % self.api
         requ_action = 'GET'
         requ_headers = {'Content-Type': 'application/json', 'x-redlock-auth': self.token}
@@ -45,6 +53,7 @@ class PrismaCloudAPIMixin():
 
     # pylint: disable=too-many-arguments
     def execute(self, action, endpoint, query_params=None, body_params=None, force=False):
+        self.suppress_warnings_when_ca_bundle_false()
         if not self.token:
             self.login()
         if int(time.time() - self.token_timer) > self.token_limit:

--- a/pcs_configure.py
+++ b/pcs_configure.py
@@ -10,40 +10,21 @@ args = parser.parse_args()
 
 # --Main-- #
 
-print('Configuration File:')
+print('Configuration File Name:')
 if args.config_file is None:
     print(pc_utility.DEFAULT_SETTINGS_FILE_NAME)
 else:
     print(args.config_file)
+print()
 
-if (args.username is not None and args.password is not None) and (args.api != '' or args.api_compute != ''):
+if args.username is None and args.password is None:
+    settings = pc_utility.read_settings_file(args.config_file)
+    pc_utility.print_settings_file(settings)
+elif args.api != '' or args.api_compute != '':
     pc_utility.write_settings_file(args)
     print('Settings saved.')
-elif args.username is None and args.password is None and args.api == '':
-    settings = pc_utility.read_settings_file(args.config_file)
-    if settings['apiBase'] is not None:
-        print('Prisma Cloud API/UI Base URL:')
-        print(settings['apiBase'])
-        print()
-    if settings['api_compute'] is not None:
-        print('(Optional) Prisma Cloud Compute Base URL:')
-        print(settings['api_compute'])
-        print()
-    if settings['username'] is not None:
-        print('Prisma Cloud Access Key:')
-        print(settings['username'])
-        print()
-    if settings['password'] is not None:
-        print('Prisma Cloud Secret Key:')
-        print(settings['password'])
-        print()
-    if settings['ca_bundle'] is not None:
-        print('(Optional) Custom CA (bundle) file:')
-        print(settings['ca_bundle'])
-        print()
-    # print('To specify these settings independent of --config_file, use:')
-    # print('-u %s -p %s --api %s --api_compute %s --ca_bundle %s' % (settings['username'], settings['password'], settings['apiBase'], settings['api_compute'], settings['ca_bundle']))
 else:
-    print('Please specify an Access Key (-u / --username), Secret Key (-p / --password), and API/UI Base URL (--api) to save your configuration.')
+    print('Please specify an Access Key / Username (-u / --username), Secret Key / Password (-p / --password), and API/UI Base URL (--api or --api_compute) to save your configuration.')
     print()
     print('Please specify nothing, other than an optional (--config_file), to view your current configuration.')
+print()


### PR DESCRIPTION
## Description

refactor cli params

deprecate apiBase in favor of api
add dash equivlents for underscore seperators
ensure params override settings file

## Motivation and Context

user reported error

## How Has This Been Tested?

manual and pylint

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist


- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
