### PR TITLE
Added Cloud Account Inventory Script and Updated API endpoint

### DIFF
--- a/pc_lib/posture/_endpoints.py
+++ b/pc_lib/posture/_endpoints.py
@@ -278,7 +278,7 @@ class EndpointsPrismaCloudAPIMixin():
         return self.execute('GET', 'cloud', query_params=query_params)
 
     def cloud_accounts_children_list_read(self, cloud_account_type, cloud_account_id):
-        return self.execute('GET', '/cloud/%s/%s/project' % (cloud_account_type, cloud_account_id))
+        return self.execute('GET', 'cloud/%s/%s/project' % (cloud_account_type, cloud_account_id))
 
     def cloud_accounts_list_names_read(self, query_params=None):
         return self.execute('GET', 'cloud/name', query_params=query_params)

--- a/pcs_cloud_account_inventory.py
+++ b/pcs_cloud_account_inventory.py
@@ -1,0 +1,49 @@
+# pylint: disable=redefined-outer-name
+""" Add discovered registries to Vulnerability->Images->Registry settings """
+
+from __future__ import print_function
+import csv
+from pc_lib import pc_api, pc_utility
+
+# --Configuration-- #
+
+parser = pc_utility.get_arg_parser()
+args = parser.parse_args()
+
+# --Helpers-- #
+
+def process_account(acct_obj,parent):
+    if acct_obj['numberOfChildAccounts'] > 0:
+        c_accounts=pc_api.cloud_accounts_children_list_read(acct_obj['cloudType'],acct_obj['accountId'])
+        for account in c_accounts:
+            process_account(account,acct_obj['accountId'])
+    if acct_obj['numberOfChildAccounts'] > 0 and parent == "":
+        pass
+    else:
+        a_dict = {
+            "name"      : acct_obj['name'],
+            "cloud"     : acct_obj['cloudType'],
+            "parent"    : parent,
+            "type"      : acct_obj['accountType'],
+            "id"        : acct_obj['accountId']
+        }
+        master_account_list.append(a_dict)
+    return 0
+
+# --Initialize-- #
+
+settings = pc_utility.get_settings(args)
+pc_api.configure(settings)
+
+# --Initialize-- #
+
+cloud_accounts_list = pc_api.cloud_accounts_list_read()
+master_account_list=[]
+for account in (cloud_accounts_list):
+    process_account(account,"")
+
+keys = master_account_list[0].keys()
+with open('output.csv', 'w', newline='') as a_file:
+    dict_writer = csv.DictWriter(a_file, keys)
+    dict_writer.writeheader()
+    dict_writer.writerows(master_account_list)

--- a/pcs_cloud_account_inventory.py
+++ b/pcs_cloud_account_inventory.py
@@ -8,6 +8,11 @@ from pc_lib import pc_api, pc_utility
 # --Configuration-- #
 
 parser = pc_utility.get_arg_parser()
+parser.add_argument(
+        '--output',
+        default='output.csv',
+        type=str,
+        help='(Optional) - Name of output file, defaults to output.csv')
 args = parser.parse_args()
 
 # --Helpers-- #
@@ -43,7 +48,7 @@ for account in (cloud_accounts_list):
     process_account(account,"")
 
 keys = master_account_list[0].keys()
-with open('output.csv', 'w', newline='') as a_file:
+with open(args.output, 'w', newline='') as a_file:
     dict_writer = csv.DictWriter(a_file, keys)
     dict_writer.writeheader()
     dict_writer.writerows(master_account_list)


### PR DESCRIPTION
## Description

Added script which pulls all accounts and subaccounts and stores as a CSV in output file selectable by user.

## Motivation and Context

No easy way to get an all encompassing view of all parent/child accounts with relationships from within the Prisma Cloud platform.

## How Has This Been Tested?

Tested against app and app3 stacks.

## Types of changes

Adds new utility to export as csv.
Also fixes the "cloud_accounts_children_list_read" endpoint wrapper within the pc_lib/posture/_endpoints.py.  There was a scenario where an additional space was added causing API POST to fail.

- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes if appropriate.
- [ X ] All new and existing tests passed.
